### PR TITLE
fixed crash of hml_short serialization

### DIFF
--- a/TonSdk.Core/src/boc/Hashmap.cs
+++ b/TonSdk.Core/src/boc/Hashmap.cs
@@ -204,7 +204,7 @@ namespace TonSdk.Core.Boc {
             var sameBitsLength = sameBitsIndex == -1 ? first.RemainderBits : sameBitsIndex;
 
             // hml_short$0 {m:#} {n:#} len:(Unary ~n) s:(n * Bit) = HmLabel ~n m;
-            if (first.ReadBit() != last.ReadBit() || m == 0) {
+            if (m == 0 || first.ReadBit() != last.ReadBit()) {
                 return serializeLabelShort(new Bits(0));
             }
 
@@ -239,11 +239,16 @@ namespace TonSdk.Core.Boc {
 
         // hml_short$0 {m:#} {n:#} len:(Unary ~n) {n <= m} s:(n * Bit) = HmLabel ~n m;
         protected Bits serializeLabelShort(Bits bits) {
-            return new BitsBuilder()
+            if (bits.Length == 0)
+                return new BitsBuilder()
+                    .StoreBit(false)
+                    .StoreBit(false)
+                    .Build();
+            else
+                return new BitsBuilder()
                 .StoreBit(false)
                 .StoreInt(-1, bits.Length)
                 .StoreBit(false)
-                .StoreBits(bits)
                 .Build();
         }
 

--- a/TonSdk.Core/src/boc/Hashmap.cs
+++ b/TonSdk.Core/src/boc/Hashmap.cs
@@ -249,6 +249,7 @@ namespace TonSdk.Core.Boc {
                 .StoreBit(false)
                 .StoreInt(-1, bits.Length)
                 .StoreBit(false)
+                .StoreBits(bits)
                 .Build();
         }
 

--- a/TonSdk.Core/test/boc/Hashmap.test.cs
+++ b/TonSdk.Core/test/boc/Hashmap.test.cs
@@ -1,0 +1,30 @@
+using TonSdk.Core.Boc;
+
+namespace TonSdk.Core.Tests;
+
+public class HashmapTest
+{
+    [Test]
+    public void ShouldSerializeDictionary()
+    {
+        var hmOptions = new HashmapOptions<int, int>()
+        {
+            KeySize = 16,
+            Serializers = new HashmapSerializers<int, int>
+            {
+                Key = k => new BitsBuilder(16).StoreInt(k, 16).Build(),
+                Value = v => new CellBuilder().StoreUInt(v, 32).Build()
+            },
+            Deserializers = null
+        };
+
+        var hm = new HashmapE<int, int>(hmOptions);
+
+        for (int i = 1; i < 100; i++)
+        {
+            hm.Set(i, Random.Shared.Next(1, 50000));
+        }
+
+        Assert.DoesNotThrow(() => hm.Serialize());
+    }
+}


### PR DESCRIPTION
- Fixed this problem #28 
- Added Some unit tests for dict serialization

![image](https://github.com/continuation-team/TonSdk.NET/assets/34582815/fbbb417c-4129-45db-9bc6-f872faa340bf)
