### PR TITLE
Changed sendBoc endpoint to sendBocReturnHash for Toncenter API V2

### DIFF
--- a/TonSdk.Client/src/HttpApi/HttpsApi.cs
+++ b/TonSdk.Client/src/HttpApi/HttpsApi.cs
@@ -182,7 +182,7 @@ namespace TonSdk.Client
             {
                 boc = boc.ToString("base64")
             };
-            var result = await new TonRequest(new RequestParameters("sendBoc", requestBody), _httpClient).Call();
+            var result = await new TonRequest(new RequestParameters("sendBocReturnHash", requestBody), _httpClient).Call();
             RootSendBoc resultRoot = JsonConvert.DeserializeObject<RootSendBoc>(result);
             SendBocResult outSendBoc = resultRoot.Result;
             return outSendBoc;


### PR DESCRIPTION
sendBocReturnHash does exactly the same thing, but returns back the hash of the created transaction, that is necessary for most cases