### PR TITLE
refactor: Address property of ContractBase

### DIFF
--- a/TonSdk.Contracts/src/ContractBase.cs
+++ b/TonSdk.Contracts/src/ContractBase.cs
@@ -6,22 +6,33 @@ namespace TonSdk.Contracts
 {
     public interface ContractBaseOptions
     {
-        public int? Workchain { get; set; }
         public Cell Code { get; set; }
     }
-    
+
     public abstract class ContractBase
     {
         protected Cell _code;
         protected StateInit _stateInit;
-        protected Address? _address;
-        
-        public Cell Code => _code;
 
+        public Cell Code => _code;
         public StateInit StateInit => _stateInit;
 
-        public Address Address => _address;
+
+        /// <summary>
+        ///  Get wallet address with default AddressStringifyOptions
+        /// </summary>
+        /// <param name="options">
+        /// AddressStringifyOptions
+        /// <remarks>Default options: AddressStringifyOptions(bounceable: false,testOnly: false,urlSafe: true)</remarks>
+        /// </param>
+        /// <returns></returns>
+        public virtual Address ToAddress(IAddressRewriteOptions? options = null)
+        {
+            var defaultOptions = new AddressStringifyOptions(false, false, true);
+            return new Address(options?.Workchain ?? defaultOptions.Workchain!.Value, _stateInit,
+                options ?? defaultOptions);
+        }
+
         protected abstract StateInit BuildStateInit();
-        
     }
 }

--- a/TonSdk.Contracts/src/jetton/JettonMinter.cs
+++ b/TonSdk.Contracts/src/jetton/JettonMinter.cs
@@ -8,7 +8,6 @@ namespace TonSdk.Contracts.Jetton
     {
         public Address AdminAddress { get; set; }
         public IJettonContentStorage JettonContent { get; set; }
-        public int? Workchain { get; set; }
         public Cell? Code { get; set; }
     }
     
@@ -64,7 +63,6 @@ namespace TonSdk.Contracts.Jetton
             _content = options.JettonContent;
             _code = options.Code ?? Cell.From(Models.JETTON_MINTER_CODE_HEX);
             _stateInit = BuildStateInit();
-            _address = new Address(options.Workchain ?? 0, _stateInit);
         }
 
         public static Cell CreateMintRequest(JettonMintOptions opt)

--- a/TonSdk.Contracts/src/nft/NftCollection.cs
+++ b/TonSdk.Contracts/src/nft/NftCollection.cs
@@ -8,7 +8,6 @@ namespace TonSdk.Contracts.nft
 {
     public struct NftCollectionOptions : ContractBaseOptions
     {
-        public int? Workchain { get; set; }
         public Cell? Code { get; set; }
         
         public Cell? NftItemCode { get; set; }
@@ -60,7 +59,6 @@ namespace TonSdk.Contracts.nft
             
             _code = options.Code ?? Cell.From(Models.NFT_COLLECTION_CODE_HEX);
             _stateInit = BuildStateInit();
-            _address = new Address(options.Workchain ?? 0, _stateInit);
         }
         
         public static Cell CreateMintRequest(NftMintOptions opt)

--- a/TonSdk.Contracts/src/wallet/HighloadV1.cs
+++ b/TonSdk.Contracts/src/wallet/HighloadV1.cs
@@ -29,7 +29,7 @@ namespace TonSdk.Contracts.Wallet
             _code = Cell.From(WalletSources.HighloadV1);
             _subwalletId = opt.SubwalletId ?? WalletTraits.SUBWALLET_ID;
             _publicKey = opt.PublicKey;
-            _stateInit = buildStateInit();
+            _stateInit = BuildStateInit();
         }
 
         public HighloadV1Storage ParseStorage(CellSlice slice)
@@ -43,7 +43,7 @@ namespace TonSdk.Contracts.Wallet
             };
         }
 
-        protected sealed override StateInit buildStateInit()
+        protected sealed override StateInit BuildStateInit()
         {
             var data = new CellBuilder()
                 .StoreUInt(0, 32) // seqno

--- a/TonSdk.Contracts/src/wallet/HighloadV1.cs
+++ b/TonSdk.Contracts/src/wallet/HighloadV1.cs
@@ -1,5 +1,4 @@
 using System;
-using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;
 
@@ -8,7 +7,6 @@ namespace TonSdk.Contracts.Wallet
     public struct HighloadV1Options
     {
         public byte[] PublicKey;
-        public int? Workchain;
         public uint? SubwalletId;
     }
 

--- a/TonSdk.Contracts/src/wallet/HighloadV1.cs
+++ b/TonSdk.Contracts/src/wallet/HighloadV1.cs
@@ -32,7 +32,6 @@ namespace TonSdk.Contracts.Wallet
             _subwalletId = opt.SubwalletId ?? WalletTraits.SUBWALLET_ID;
             _publicKey = opt.PublicKey;
             _stateInit = buildStateInit();
-            _address = new Address(opt.Workchain ?? 0, _stateInit);
         }
 
         public HighloadV1Storage ParseStorage(CellSlice slice)
@@ -85,7 +84,7 @@ namespace TonSdk.Contracts.Wallet
 
             return new ExternalInMessage(new ExternalInMessageOptions
             {
-                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = Address }),
+                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = ToAddress() }),
                 Body = bodyBuilder.Build(),
                 StateInit = seqno == 0 ? _stateInit : null
             });
@@ -102,7 +101,7 @@ namespace TonSdk.Contracts.Wallet
 
             return new ExternalInMessage(new ExternalInMessageOptions
             {
-                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = Address }),
+                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = ToAddress() }),
                 Body = bodyBuilder.Build(),
                 StateInit = _stateInit
             });

--- a/TonSdk.Contracts/src/wallet/HighloadV2.cs
+++ b/TonSdk.Contracts/src/wallet/HighloadV2.cs
@@ -1,5 +1,4 @@
 using System;
-using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;
 
@@ -8,7 +7,6 @@ namespace TonSdk.Contracts.Wallet
     public struct HighloadV2Options
     {
         public byte[] PublicKey;
-        public int? Workchain;
         public uint? SubwalletId;
     }
 

--- a/TonSdk.Contracts/src/wallet/HighloadV2.cs
+++ b/TonSdk.Contracts/src/wallet/HighloadV2.cs
@@ -31,7 +31,7 @@ namespace TonSdk.Contracts.Wallet
             _code = Cell.From(WalletSources.HighloadV2);
             _publicKey = opt.PublicKey;
             _subwalletId = opt.SubwalletId ?? WalletTraits.SUBWALLET_ID;
-            _stateInit = buildStateInit();
+            _stateInit = BuildStateInit();
 
             _oldQueries_hmapOptions = new HashmapOptions<int, WalletTransfer>
             {
@@ -69,7 +69,7 @@ namespace TonSdk.Contracts.Wallet
             };
         }
 
-        protected sealed override StateInit buildStateInit()
+        protected sealed override StateInit BuildStateInit()
         {
             var data = new CellBuilder()
                 .StoreUInt(_subwalletId, 32)

--- a/TonSdk.Contracts/src/wallet/PreprocessedV2.cs
+++ b/TonSdk.Contracts/src/wallet/PreprocessedV2.cs
@@ -1,5 +1,4 @@
 using System;
-using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;
 

--- a/TonSdk.Contracts/src/wallet/PreprocessedV2.cs
+++ b/TonSdk.Contracts/src/wallet/PreprocessedV2.cs
@@ -23,7 +23,7 @@ namespace TonSdk.Contracts.Wallet
         {
             _code = Cell.From(WalletSources.PreprocessedV2);
             _publicKey = opt.PublicKey;
-            _stateInit = buildStateInit();
+            _stateInit = BuildStateInit();
         }
 
         public PreprocessedV2Storage ParseStorage(CellSlice slice)
@@ -36,7 +36,7 @@ namespace TonSdk.Contracts.Wallet
             };
         }
 
-        protected sealed override StateInit buildStateInit()
+        protected sealed override StateInit BuildStateInit()
         {
             var data = new CellBuilder()
                 .StoreBytes(_publicKey)

--- a/TonSdk.Contracts/src/wallet/PreprocessedV2.cs
+++ b/TonSdk.Contracts/src/wallet/PreprocessedV2.cs
@@ -3,36 +3,42 @@ using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;
 
-namespace TonSdk.Contracts.Wallet {
-    public struct PreprocessedV2Options {
+namespace TonSdk.Contracts.Wallet
+{
+    public struct PreprocessedV2Options
+    {
         public byte[] PublicKey;
         public int? Workchain;
     }
 
-    public struct PreprocessedV2Storage {
+    public struct PreprocessedV2Storage
+    {
         public byte[] PublicKey;
         public uint Seqno;
     }
 
 
-    public class PreprocessedV2 : WalletBase {
-
-        public PreprocessedV2(PreprocessedV2Options opt) {
+    public class PreprocessedV2 : WalletBase
+    {
+        public PreprocessedV2(PreprocessedV2Options opt)
+        {
             _code = Cell.From(WalletSources.PreprocessedV2);
             _publicKey = opt.PublicKey;
             _stateInit = buildStateInit();
-            _address = new Address(opt.Workchain ?? 0, _stateInit);
         }
 
-        public PreprocessedV2Storage ParseStorage(CellSlice slice) {
+        public PreprocessedV2Storage ParseStorage(CellSlice slice)
+        {
             BlockUtils.CheckUnderflow(slice, 16 + 256, null);
-            return new PreprocessedV2Storage {
+            return new PreprocessedV2Storage
+            {
                 PublicKey = slice.LoadBytes(32),
                 Seqno = (uint)slice.LoadUInt(16),
             };
         }
 
-        protected sealed override StateInit buildStateInit() {
+        protected sealed override StateInit buildStateInit()
+        {
             var data = new CellBuilder()
                 .StoreBytes(_publicKey)
                 .StoreUInt(0, 16)
@@ -40,8 +46,10 @@ namespace TonSdk.Contracts.Wallet {
             return new StateInit(new StateInitOptions { Code = _code, Data = data });
         }
 
-        public ExternalInMessage CreateTransferMessage(WalletTransfer[] transfers, uint seqno, uint timeout = 60) {
-            if (transfers.Length == 0 || transfers.Length > 255) {
+        public ExternalInMessage CreateTransferMessage(WalletTransfer[] transfers, uint seqno, uint timeout = 60)
+        {
+            if (transfers.Length == 0 || transfers.Length > 255)
+            {
                 throw new Exception("PreprocessedV2: can make only 1 to 255 transfers per operation.");
             }
 
@@ -51,9 +59,11 @@ namespace TonSdk.Contracts.Wallet {
 
             var actions = new OutAction[transfers.Length];
 
-            for (var i = 0; i < transfers.Length; i++) {
+            for (var i = 0; i < transfers.Length; i++)
+            {
                 var transfer = transfers[i];
-                var action = new ActionSendMsg(new ActionSendMsgOptions {
+                var action = new ActionSendMsg(new ActionSendMsgOptions
+                {
                     Mode = transfer.Mode,
                     OutMsg = transfer.Message
                 });
@@ -62,21 +72,24 @@ namespace TonSdk.Contracts.Wallet {
 
             bodyBuilder.StoreRef(new OutList(new OutListOptions { Actions = actions }).Cell);
 
-            return new ExternalInMessage(new ExternalInMessageOptions {
-                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = Address }),
+            return new ExternalInMessage(new ExternalInMessageOptions
+            {
+                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = ToAddress() }),
                 Body = bodyBuilder.Build(),
                 StateInit = seqno == 0 ? _stateInit : null
             });
         }
 
-        public ExternalInMessage CreateDeployMessage() {
+        public ExternalInMessage CreateDeployMessage()
+        {
             var bodyBuilder = new CellBuilder()
                 .StoreInt(-1, 64)
                 .StoreUInt(0, 16) // seqno = 0
                 .StoreRef(new CellBuilder().Build()); // empty out_list
 
-            return new ExternalInMessage(new ExternalInMessageOptions {
-                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = Address }),
+            return new ExternalInMessage(new ExternalInMessageOptions
+            {
+                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = ToAddress() }),
                 Body = bodyBuilder.Build(),
                 StateInit = _stateInit
             });

--- a/TonSdk.Contracts/src/wallet/Wallet.cs
+++ b/TonSdk.Contracts/src/wallet/Wallet.cs
@@ -1,4 +1,3 @@
-using System;
 using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;

--- a/TonSdk.Contracts/src/wallet/Wallet.cs
+++ b/TonSdk.Contracts/src/wallet/Wallet.cs
@@ -6,9 +6,7 @@ namespace TonSdk.Contracts.Wallet
 {
     public abstract class WalletBase : ContractBase
     {
-        protected Cell _code;
         protected byte[] _publicKey;
-        protected StateInit _stateInit;
         public byte[] PublicKey => _publicKey;
     }
 

--- a/TonSdk.Contracts/src/wallet/Wallet.cs
+++ b/TonSdk.Contracts/src/wallet/Wallet.cs
@@ -1,13 +1,15 @@
+using System;
 using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;
 
-namespace TonSdk.Contracts.Wallet {
-    public abstract class WalletBase {
+namespace TonSdk.Contracts.Wallet
+{
+    public abstract class WalletBase
+    {
         protected Cell _code;
         protected byte[] _publicKey;
         protected StateInit _stateInit;
-        protected Address _address;
 
         public Cell Code => _code;
 
@@ -15,22 +17,38 @@ namespace TonSdk.Contracts.Wallet {
 
         public StateInit StateInit => _stateInit;
 
-        public Address Address => _address;
+        /// <summary>
+        ///  Get wallet address with default AddressStringifyOptions
+        /// </summary>
+        /// <param name="options">
+        /// AddressStringifyOptions
+        /// <remarks>Default options: AddressStringifyOptions(bounceable: false,testOnly: false,urlSafe: true)</remarks>
+        /// </param>
+        /// <returns></returns>
+        public virtual Address ToAddress(IAddressRewriteOptions options = null)
+        {
+            var defaultOptions = new AddressStringifyOptions(false, false, true);
+            _stateInit = buildStateInit();
+            return new Address(options?.Workchain ?? defaultOptions.Workchain!.Value, _stateInit, defaultOptions);
+        }
 
         protected abstract StateInit buildStateInit();
     }
 
-    public struct WalletTransfer {
+    public struct WalletTransfer
+    {
         public MessageX Message;
         public byte Mode;
     }
 
-    public static class WalletTraits {
+    public static class WalletTraits
+    {
         public const uint SUBWALLET_ID = 698983191;
         // why 698983191?? -> https://github.com/ton-blockchain/ton/blob/4b940f8bad9c2d3bf44f196f6995963c7cee9cc3/tonlib/tonlib/TonlibClient.cpp#L2420
     }
 
-    public static class WalletSources {
+    public static class WalletSources
+    {
         public const string V3R1 =
             "B5EE9C724101010100620000C0FF0020DD2082014C97BA9730ED44D0D70B1FE0A4F2608308D71820D31FD31FD31FF82313BBF263ED44D0D31FD31FD3FFD15132BAF2A15144BAF2A204F901541055F910F2A3F8009320D74A96D307D402FB00E8D101A4C8CB1FCB1FCBFFC9ED543FBE6EE0";
 
@@ -45,7 +63,7 @@ namespace TonSdk.Contracts.Wallet {
 
         public const string HighloadV2 =
             "B5EE9C724101090100E5000114FF00F4A413F4BCF2C80B010201200203020148040501EAF28308D71820D31FD33FF823AA1F5320B9F263ED44D0D31FD33FD3FFF404D153608040F40E6FA131F2605173BAF2A207F901541087F910F2A302F404D1F8007F8E16218010F4786FA5209802D307D43001FB009132E201B3E65B8325A1C840348040F4438AE63101C8CB1F13CB3FCBFFF400C9ED54080004D03002012006070017BD9CE76A26869AF98EB85FFC0041BE5F976A268698F98E99FE9FF98FA0268A91040207A0737D098C92DBFC95DD1F140034208040F4966FA56C122094305303B9DE2093333601926C21E2B39F9E545A";
-        
+
         public const string HighloadV1 =
             "B5EE9C7241020801000097000114FF00F4A413F4BCF2C80B01020120030200B8F28308D71820D31FD31FD31F02F823BBF263ED44D0D31FD31FD3FFD15132BAF2A15144BAF2A204F901541055F910F2A3F404D1F8007F8E16218010F4786FA5209802D307D43001FB009132E201B3E65B01A4C8CB1FCB1FCBFFC9ED54020148070402014806050011B8C97ED44D0D70B1F80017BB39CED44D0D33F31D70BFF80004D03025869C35";
 

--- a/TonSdk.Contracts/src/wallet/Wallet.cs
+++ b/TonSdk.Contracts/src/wallet/Wallet.cs
@@ -4,34 +4,12 @@ using TonSdk.Core.Boc;
 
 namespace TonSdk.Contracts.Wallet
 {
-    public abstract class WalletBase
+    public abstract class WalletBase : ContractBase
     {
         protected Cell _code;
         protected byte[] _publicKey;
         protected StateInit _stateInit;
-
-        public Cell Code => _code;
-
         public byte[] PublicKey => _publicKey;
-
-        public StateInit StateInit => _stateInit;
-
-        /// <summary>
-        ///  Get wallet address with default AddressStringifyOptions
-        /// </summary>
-        /// <param name="options">
-        /// AddressStringifyOptions
-        /// <remarks>Default options: AddressStringifyOptions(bounceable: false,testOnly: false,urlSafe: true)</remarks>
-        /// </param>
-        /// <returns></returns>
-        public virtual Address ToAddress(IAddressRewriteOptions options = null)
-        {
-            var defaultOptions = new AddressStringifyOptions(false, false, true);
-            _stateInit = buildStateInit();
-            return new Address(options?.Workchain ?? defaultOptions.Workchain!.Value, _stateInit, defaultOptions);
-        }
-
-        protected abstract StateInit buildStateInit();
     }
 
     public struct WalletTransfer

--- a/TonSdk.Contracts/src/wallet/WalletV3.cs
+++ b/TonSdk.Contracts/src/wallet/WalletV3.cs
@@ -3,26 +3,32 @@ using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;
 
-namespace TonSdk.Contracts.Wallet {
-    public struct WalletV3Options {
+namespace TonSdk.Contracts.Wallet
+{
+    public struct WalletV3Options
+    {
         public byte[] PublicKey;
         public int? Workchain;
         public uint? SubwalletId;
     }
 
-    public struct WalletV3Storage {
+    public struct WalletV3Storage
+    {
         public uint Seqno;
         public uint SubwalletId;
         public byte[] PublicKey;
     }
-    
-    public class WalletV3 : WalletBase {
+
+    public class WalletV3 : WalletBase
+    {
         private uint _subwalletId;
 
         public uint SubwalletId => _subwalletId;
 
-        public WalletV3(WalletV3Options opt, uint revision = 2) {
-            if (revision != 1 && revision != 2) {
+        public WalletV3(WalletV3Options opt, uint revision = 2)
+        {
+            if (revision != 1 && revision != 2)
+            {
                 throw new Exception("Unsupported revision. Only 1 and 2 are supported");
             }
 
@@ -30,19 +36,21 @@ namespace TonSdk.Contracts.Wallet {
             _publicKey = opt.PublicKey;
             _subwalletId = opt.SubwalletId ?? WalletTraits.SUBWALLET_ID;
             _stateInit = buildStateInit();
-            _address = new Address(opt.Workchain ?? 0, _stateInit);
         }
 
-        public WalletV3Storage ParseStorage(CellSlice slice) {
+        public WalletV3Storage ParseStorage(CellSlice slice)
+        {
             BlockUtils.CheckUnderflow(slice, 32 + 32 + 256, null);
-            return new WalletV3Storage {
+            return new WalletV3Storage
+            {
                 Seqno = (uint)slice.LoadUInt(32),
                 SubwalletId = (uint)slice.LoadUInt(32),
                 PublicKey = slice.LoadBytes(32)
             };
         }
 
-        protected sealed override StateInit buildStateInit() {
+        protected sealed override StateInit buildStateInit()
+        {
             var data = new CellBuilder()
                 .StoreUInt(0, 32)
                 .StoreUInt(_subwalletId, 32)
@@ -51,8 +59,10 @@ namespace TonSdk.Contracts.Wallet {
             return new StateInit(new StateInitOptions { Code = _code, Data = data });
         }
 
-        public ExternalInMessage CreateTransferMessage(WalletTransfer[] transfers, uint seqno, uint timeout = 60) {
-            if (transfers.Length == 0 || transfers.Length > 4) {
+        public ExternalInMessage CreateTransferMessage(WalletTransfer[] transfers, uint seqno, uint timeout = 60)
+        {
+            if (transfers.Length == 0 || transfers.Length > 4)
+            {
                 throw new Exception("WalletV3: can make only 1 to 4 transfers per operation.");
             }
 
@@ -61,27 +71,31 @@ namespace TonSdk.Contracts.Wallet {
                 .StoreUInt(DateTimeOffset.Now.ToUnixTimeSeconds() + timeout, 32)
                 .StoreUInt(seqno, 32);
 
-            foreach (var transfer in transfers) {
+            foreach (var transfer in transfers)
+            {
                 bodyBuilder
                     .StoreUInt(transfer.Mode, 8)
                     .StoreRef(transfer.Message.Cell);
             }
 
-            return new ExternalInMessage(new ExternalInMessageOptions {
-                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = Address }),
+            return new ExternalInMessage(new ExternalInMessageOptions
+            {
+                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = ToAddress() }),
                 Body = bodyBuilder.Build(),
                 StateInit = seqno == 0 ? _stateInit : null
             });
         }
 
-        public ExternalInMessage CreateDeployMessage() {
+        public ExternalInMessage CreateDeployMessage()
+        {
             var bodyBuilder = new CellBuilder()
                 .StoreUInt(_subwalletId, 32)
                 .StoreInt(-1L, 32)
                 .StoreUInt(0, 32); // seqno = 0
 
-            return new ExternalInMessage(new ExternalInMessageOptions {
-                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = Address }),
+            return new ExternalInMessage(new ExternalInMessageOptions
+            {
+                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = ToAddress() }),
                 Body = bodyBuilder.Build(),
                 StateInit = _stateInit
             });

--- a/TonSdk.Contracts/src/wallet/WalletV3.cs
+++ b/TonSdk.Contracts/src/wallet/WalletV3.cs
@@ -33,7 +33,7 @@ namespace TonSdk.Contracts.Wallet
             _code = revision == 1 ? Cell.From(WalletSources.V3R1) : Cell.From(WalletSources.V3R2);
             _publicKey = opt.PublicKey;
             _subwalletId = opt.SubwalletId ?? WalletTraits.SUBWALLET_ID;
-            _stateInit = buildStateInit();
+            _stateInit = BuildStateInit();
         }
 
         public WalletV3Storage ParseStorage(CellSlice slice)
@@ -47,7 +47,7 @@ namespace TonSdk.Contracts.Wallet
             };
         }
 
-        protected sealed override StateInit buildStateInit()
+        protected sealed override StateInit BuildStateInit()
         {
             var data = new CellBuilder()
                 .StoreUInt(0, 32)

--- a/TonSdk.Contracts/src/wallet/WalletV3.cs
+++ b/TonSdk.Contracts/src/wallet/WalletV3.cs
@@ -1,5 +1,4 @@
 using System;
-using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;
 
@@ -8,7 +7,6 @@ namespace TonSdk.Contracts.Wallet
     public struct WalletV3Options
     {
         public byte[] PublicKey;
-        public int? Workchain;
         public uint? SubwalletId;
     }
 

--- a/TonSdk.Contracts/src/wallet/WalletV4.cs
+++ b/TonSdk.Contracts/src/wallet/WalletV4.cs
@@ -33,7 +33,7 @@ namespace TonSdk.Contracts.Wallet
             _code = revision == 1 ? Cell.From(WalletSources.V4R1) : Cell.From(WalletSources.V4R2);
             _publicKey = opt.PublicKey;
             _subwalletId = opt.SubwalletId ?? WalletTraits.SUBWALLET_ID;
-            _stateInit = buildStateInit();
+            _stateInit = BuildStateInit();
         }
 
         public WalletV4Storage ParseStorage(CellSlice slice)
@@ -68,7 +68,7 @@ namespace TonSdk.Contracts.Wallet
             };
         }
         
-        protected sealed override StateInit buildStateInit()
+        protected sealed override StateInit BuildStateInit()
         {
             var data = new CellBuilder()
                 .StoreUInt(0, 32)

--- a/TonSdk.Contracts/src/wallet/WalletV4.cs
+++ b/TonSdk.Contracts/src/wallet/WalletV4.cs
@@ -3,14 +3,17 @@ using TonSdk.Core;
 using TonSdk.Core.Block;
 using TonSdk.Core.Boc;
 
-namespace TonSdk.Contracts.Wallet {
-    public struct WalletV4Options {
+namespace TonSdk.Contracts.Wallet
+{
+    public struct WalletV4Options
+    {
         public byte[] PublicKey;
-        public int? Workchain;
+
         public uint? SubwalletId;
     }
 
-    public struct WalletV4Storage {
+    public struct WalletV4Storage
+    {
         public uint Seqno;
         public uint SubwalletId;
         public byte[] PublicKey;
@@ -18,37 +21,44 @@ namespace TonSdk.Contracts.Wallet {
     }
 
 
-    public class WalletV4 : WalletBase {
+    public class WalletV4 : WalletBase
+    {
         private uint _subwalletId;
 
         public uint SubwalletId => _subwalletId;
 
-        public WalletV4(WalletV4Options opt, uint revision = 2) {
+        public WalletV4(WalletV4Options opt, uint revision = 2)
+        {
             if (revision != 1 && revision != 2) throw new Exception("Unsupported revision. Only 1 and 2 are supported");
             _code = revision == 1 ? Cell.From(WalletSources.V4R1) : Cell.From(WalletSources.V4R2);
             _publicKey = opt.PublicKey;
             _subwalletId = opt.SubwalletId ?? WalletTraits.SUBWALLET_ID;
             _stateInit = buildStateInit();
-            _address = new Address(opt.Workchain ?? 0, _stateInit);
         }
 
-        public WalletV4Storage ParseStorage(CellSlice slice) {
+        public WalletV4Storage ParseStorage(CellSlice slice)
+        {
             BlockUtils.CheckUnderflow(slice, 32 + 32 + 256 + 1, null);
-            return new WalletV4Storage {
+            return new WalletV4Storage
+            {
                 Seqno = (uint)slice.LoadUInt(32),
                 SubwalletId = (uint)slice.LoadUInt(32),
                 PublicKey = slice.LoadBytes(32),
-                Plugins = slice.LoadDict(new HashmapOptions<Address, bool> {
+                Plugins = slice.LoadDict(new HashmapOptions<Address, bool>
+                {
                     KeySize = 8 + 256,
-                    Serializers = new HashmapSerializers<Address, bool> {
+                    Serializers = new HashmapSerializers<Address, bool>
+                    {
                         Key = k => new BitsBuilder(8 + 256)
                             .StoreInt(k.GetWorkchain(), 8)
                             .StoreBytes(k.GetHash())
                             .Build(),
                         Value = v => new CellBuilder().Build()
                     },
-                    Deserializers = new HashmapDeserializers<Address, bool> {
-                        Key = kb => {
+                    Deserializers = new HashmapDeserializers<Address, bool>
+                    {
+                        Key = kb =>
+                        {
                             var ks = kb.Parse();
                             return new Address((int)ks.LoadInt(8), ks.LoadBytes(32));
                         },
@@ -57,8 +67,9 @@ namespace TonSdk.Contracts.Wallet {
                 })
             };
         }
-
-        protected sealed override StateInit buildStateInit() {
+        
+        protected sealed override StateInit buildStateInit()
+        {
             var data = new CellBuilder()
                 .StoreUInt(0, 32)
                 .StoreUInt(_subwalletId, 32)
@@ -68,8 +79,10 @@ namespace TonSdk.Contracts.Wallet {
             return new StateInit(new StateInitOptions { Code = _code, Data = data });
         }
 
-        public ExternalInMessage CreateTransferMessage(WalletTransfer[] transfers, uint seqno, uint timeout = 60) {
-            if (transfers.Length == 0 || transfers.Length > 4) {
+        public ExternalInMessage CreateTransferMessage(WalletTransfer[] transfers, uint seqno, uint timeout = 60)
+        {
+            if (transfers.Length == 0 || transfers.Length > 4)
+            {
                 throw new Exception("WalletV4: can make only 1 to 4 transfers per operation.");
             }
 
@@ -79,28 +92,32 @@ namespace TonSdk.Contracts.Wallet {
                 .StoreUInt(seqno, 32)
                 .StoreUInt(0, 8); // op::simple_send
 
-            foreach (var transfer in transfers) {
+            foreach (var transfer in transfers)
+            {
                 bodyBuilder
                     .StoreUInt(transfer.Mode, 8)
                     .StoreRef(transfer.Message.Cell);
             }
 
-            return new ExternalInMessage(new ExternalInMessageOptions {
-                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = Address }),
+            return new ExternalInMessage(new ExternalInMessageOptions
+            {
+                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = ToAddress() }),
                 Body = bodyBuilder.Build(),
                 StateInit = seqno == 0 ? _stateInit : null
             });
         }
 
-        public ExternalInMessage CreateDeployMessage() {
+        public ExternalInMessage CreateDeployMessage()
+        {
             var bodyBuilder = new CellBuilder()
                 .StoreUInt(_subwalletId, 32)
                 .StoreInt(-1, 32)
                 .StoreUInt(0, 32) // seqno = 0
                 .StoreUInt(0, 8); // op::simple_send
 
-            return new ExternalInMessage(new ExternalInMessageOptions {
-                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = Address }),
+            return new ExternalInMessage(new ExternalInMessageOptions
+            {
+                Info = new ExtInMsgInfo(new ExtInMsgInfoOptions { Dest = ToAddress() }),
                 Body = bodyBuilder.Build(),
                 StateInit = _stateInit
             });


### PR DESCRIPTION
Refactoring the Address property of ContractBase

**Why?**
Ton's Address is divided into bounceable/unbounceable, mainnet/testnet. A fixed Address returns a specific type of address, which is obfuscated.

**Specific optimization**

Remove the fixed address and replace the property with a method that accepts an IAddressRewriteOptions parameter