### PR TITLE
Fix uri may be an empty string

### DIFF
--- a/TonSdk.Client/src/Client/Jetton/JettonUtils.cs
+++ b/TonSdk.Client/src/Client/Jetton/JettonUtils.cs
@@ -109,7 +109,7 @@ namespace TonSdk.Client
             }
 
             JettonContent jettonContent = new JettonContent(dataDict);
-            if (jettonContent.Uri != null) jettonContent = await ParseOffChainUri(jettonContent);
+            if (!string.IsNullOrEmpty(jettonContent.Uri)) jettonContent = await ParseOffChainUri(jettonContent);
             return jettonContent;
         }
 


### PR DESCRIPTION
When I run this code, I get a bug.
jettonContent.Uri may be an empty string.

```c#
TonClient tonClient = new TonClient(TonClientType.HTTP_TONCENTERAPIV3, new HttpParameters() { ApiKey = "xxx", Endpoint = "https://toncenter.com/api/v3/" });
Address jettonMasterContract = new Address("EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs");
Address address = new Address("EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs");
Address jettonWallet = await tonClient.Jetton.GetWalletAddress(jettonMasterContract, address);
var balance = await tonClient.Jetton.GetBalance(jettonWallet);
```