### PR TITLE
Fix int256 encoding in TLWriteBuffer

### DIFF
--- a/TonSdk.Adnl/src/TL/TLWriteBuffer.cs
+++ b/TonSdk.Adnl/src/TL/TLWriteBuffer.cs
@@ -59,12 +59,19 @@ namespace TonSdk.Adnl.TL
         public void WriteInt256(BigInteger val)
         {
             EnsureSize(32);
-            byte[] bytes = val.ToByteArray();
-            if (bytes.Length != 32)
+            Span<byte> buffer = stackalloc byte[32];
+            buffer.Clear();
+            if (!val.TryWriteBytes(buffer, out var bytesWritten))
             {
                 throw new Exception("Invalid int256 length");
             }
-            _writer.Write(bytes);
+            if (val < 0 && bytesWritten < 32)
+            {
+                // two's complement representation
+                buffer[bytesWritten..].Fill(0xFF);
+            }
+
+            _writer.Write(buffer);
         }
 
         public void WriteBytes(byte[] data, int size)

--- a/TonSdk.Adnl/test/TLWriteBufferTests.cs
+++ b/TonSdk.Adnl/test/TLWriteBufferTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Numerics;
+using System.Security.Cryptography;
+using NUnit.Framework;
+using TonSdk.Adnl.TL;
+
+namespace TonSdk.Adnl.Tests;
+
+public class TLWriteBufferTests
+{
+    [Test]
+    public void Test_Int256FromRandomBytesCanBeEncoded()
+    {
+        // There is 1/256 chance that last byte will be 0 (biginteger is encoded as little-endian)
+        // Check x100 samples
+        for (var i = 0; i < 256 * 100; ++i)
+        {
+            var randomBytes = GenerateRandomBytes(32);
+
+            var queryId = new BigInteger(randomBytes);
+
+            EnsureCanBeWrittenAndReadBack(queryId);
+        }
+    }
+
+    [Test]
+    public void Test_Int256WithZeroLastByteCanBeWritten()
+    {
+        var bytes = new byte[32];
+        for (var i = 0; i < 31; ++i)
+        {
+            bytes[i] = (byte)i;
+        }
+
+        bytes[31] = 0;
+
+        var queryId = new BigInteger(bytes);
+
+        EnsureCanBeWrittenAndReadBack(queryId);
+    }
+
+    private static void EnsureCanBeWrittenAndReadBack(BigInteger value)
+    {
+        var writeBuffer = new TLWriteBuffer();
+        writeBuffer.WriteInt256(value);
+
+        var writtenBytes = writeBuffer.Build();
+        var restoredValue = new BigInteger(writtenBytes);
+
+        Assert.That(restoredValue, Is.EqualTo(value));
+    }
+
+    // AdnlKeys generation logic
+    private static byte[] GenerateRandomBytes(int byteSize)
+    {
+        using RandomNumberGenerator randomNumberGenerator = RandomNumberGenerator.Create();
+        byte[] randomBytes = new byte[byteSize];
+        randomNumberGenerator.GetBytes(randomBytes);
+        return randomBytes;
+    }
+}


### PR DESCRIPTION
LiteClientEncoder.EncodeBase generates random query ids of 32 bytes. Then they are converted to BigInteger and passed to TLWriteBuffer.WriteInt256. WriteInt256 converts BigInteger back to byte array and checks if it length is 32. If it is not, it throws

The problem is: if last (most significant) byte of generated query id is zero, BigInteger.ToByteArray will return 31 (or less) bytes

So now approximately 1/256 requests will randomly fail

The fix is: we manually write remaining bytes (0 for positive big integers and 0xFF for negative, because they are stored as two's compliments)

