### PR TITLE
Fixing An Issue in retrieving Master Jetton Data with white space Uri

### DIFF
--- a/TonSdk.Client/src/Client/Jetton/Jetton.cs
+++ b/TonSdk.Client/src/Client/Jetton/Jetton.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Numerics;
-using System.Reflection.Metadata;
 using System.Threading.Tasks;
 using TonSdk.Client.Stack;
 using TonSdk.Core;

--- a/TonSdk.Client/src/Client/Jetton/JettonUtils.cs
+++ b/TonSdk.Client/src/Client/Jetton/JettonUtils.cs
@@ -109,7 +109,10 @@ namespace TonSdk.Client
             }
 
             JettonContent jettonContent = new JettonContent(dataDict);
-            if (jettonContent.Uri != null) jettonContent = await ParseOffChainUri(jettonContent);
+
+            // Fixed here: if uri is white space, it will cause an exception
+
+            if (!string.IsNullOrWhiteSpace(jettonContent.Uri)) jettonContent = await ParseOffChainUri(jettonContent);
             return jettonContent;
         }
 

--- a/TonSdk.Client/src/HttpApi/HttpsApi.cs
+++ b/TonSdk.Client/src/HttpApi/HttpsApi.cs
@@ -170,6 +170,9 @@ namespace TonSdk.Client
                 method = method,
                 stack = stack ?? Array.Empty<string[]>()
             };
+
+            
+
             var result = await new TonRequest(new RequestParameters("runGetMethod", requestBody), _httpClient).Call();
             RootRunGetMethod resultRoot = JsonConvert.DeserializeObject<RootRunGetMethod>(result);
             RunGetMethodResult outRunGetMethod = new RunGetMethodResult(resultRoot.Result);

--- a/TonSdk.Client/src/HttpApi/TonRequest.cs
+++ b/TonSdk.Client/src/HttpApi/TonRequest.cs
@@ -59,6 +59,9 @@ namespace TonSdk.Client
             });
 
             StringContent content = new StringContent(data, System.Text.Encoding.UTF8, "application/json");
+
+            Console.Write("running http call method", _params.MethodName, _params.RequestBody);
+
             HttpResponseMessage response = await _httpClient.PostAsync(string.Empty, content);
             
             if (!response.IsSuccessStatusCode)


### PR DESCRIPTION
In JettonUtils ParseOnChain method. If jettonContent.Uri is a white space, it throws and exception and fail to parse data.