### PR TITLE
Fix Coins not parsing with Invariant Culture

### DIFF
--- a/TonSdk.Core/src/Coins.cs
+++ b/TonSdk.Core/src/Coins.cs
@@ -256,12 +256,26 @@ namespace TonSdk.Core {
                     result = (decimal)doubleValue;
                     return true;
                 }
+            }
+            catch (CultureNotFoundException)
+            {
+                if (decimal.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out result))
+                {
+                    return true;
+                }
 
-                return false;
+                double doubleValue;
+                if (double.TryParse(value.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out doubleValue))
+                {
+                    result = (decimal)doubleValue;
+                    return true;
+                }
             }
             catch {
                 return false;
             }
+
+            return false;
         }
 
         private static bool IsCoins(object value) {
@@ -269,12 +283,21 @@ namespace TonSdk.Core {
         }
 
         private static int GetDigitsAfterDecimalPoint(decimal number) {
-            string[] parts = number.ToString(new CultureInfo("en-US")).Split('.');
-            if (parts.Length == 2) {
-                return parts[1].Length;
+            try
+            {
+                string[] parts = number.ToString(new CultureInfo("en-US")).Split('.');
+                if (parts.Length == 2)
+                    return parts[1].Length;
+                else
+                    return 0;
             }
-            else {
-                return 0;
+            catch (CultureNotFoundException)
+            {
+                string[] parts = number.ToString(CultureInfo.InvariantCulture).Split('.');
+                if (parts.Length == 2)
+                    return parts[1].Length;
+                else
+                    return 0;
             }
         }
 

--- a/TonSdk.Core/test/TonSdk.Core.Tests.csproj
+++ b/TonSdk.Core/test/TonSdk.Core.Tests.csproj
@@ -6,6 +6,8 @@
         <Nullable>enable</Nullable>
         <RootNamespace>TonSdk.Core.Tests</RootNamespace>
 
+        <InvariantGlobalization>true</InvariantGlobalization>
+      
         <IsPackable>false</IsPackable>
         <IsTestProject>true</IsTestProject>
     </PropertyGroup>


### PR DESCRIPTION
Solution for https://github.com/continuation-team/TonSdk.NET/issues/134

Other options should be considered too, as [exception handling is not CPU efficient](https://stackoverflow.com/questions/39710941/try-catch-vs-if-performance-in-c-sharp):
- Use invariant culture only (especially if project already has in-house culture logic, e..g `string str = value?.ToString().Replace(",", ".");` in Coins constructor)
- Compare current culture to invariant in the 2 methods involved. i.e. `CultureInfo.CurrentCulture == CultureInfo.InvariantCulture`

Relatively to the [Issue](https://github.com/continuation-team/TonSdk.NET/issues/134), the tests are passed.
![image](https://github.com/user-attachments/assets/c0a1e3e9-abe7-412c-9bb8-3dedb86ecc66)
